### PR TITLE
[Bugfix] Remove flock.js source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [Script] Remove source maps
+
 ## [1.2.0] - 2022-09-06
 ### Changed
 - [Dashboard] Optmize bundle size and Core Web Vitals

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "parcel",
     "watch": "parcel watch",
-    "build": "parcel build"
+    "build": "parcel build --no-source-maps"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
# Description

Don't generate source maps when building `flock.js` script. Source code is publicly available, and [UNPKG](https://unpkg.com/) has some issues resolving relative paths. So we're removing them from now on.

If you're reading this and you need the source maps, or just think otherwise, just open a ticket and we'll discuss this.

We're prioritizing having a simple url for the `<script>` tag.

Fixes #24 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# How Has This Been Tested?

Build the script locally, inject in a `localhost` website and check we don't get any 404.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have update the [CHANGELOG](https://github.com/tinybirdco/web-analytics-starter-kit/blob/main/CHANGELOG.md)
- [x] New and existing unit tests pass locally with my changes
