### PR TITLE
[Bugfix] Stop using Google's favicon service

### DIFF
--- a/dashboard/lib/hooks/use-domain.ts
+++ b/dashboard/lib/hooks/use-domain.ts
@@ -27,7 +27,7 @@ async function getDomain(): Promise<DomainData> {
   `)
   const domain = data[0]['domain'];
   const logo = domain
-    ? `https://s2.googleusercontent.com/s2/favicons?domain=${domain}`
+    ? `https://${domain}/favicon.ico`
     : FALLBACK_LOGO
 
   return {


### PR DESCRIPTION
# Description

Stop using Google's favicon service.

Now the dashboard will just look for `/favicon.ico` in the detected domain. We'll probably detect fewer favicons, but we're prioritizing use privacy. 

Fixes #30 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# How Has This Been Tested?

Test that some favicons are still working, and other don't.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have update the [CHANGELOG](https://github.com/tinybirdco/web-analytics-starter-kit/blob/main/CHANGELOG.md)
- [x] New and existing unit tests pass locally with my changes
