### PR TITLE
[Bugfix] Fix `analytics_pages` query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [Dashboard] Fix total KPIs for arbitrary date ranges (#37)
 - [Dashboard] Fix tooltip for the last data point in the chart
+- [Data project]  Fix `analytics_pages` query
 
 ## [1.2.2] - 2022-09-28
 ### Fixed

--- a/tinybird/pipes/analytics_pages.pipe
+++ b/tinybird/pipes/analytics_pages.pipe
@@ -10,7 +10,7 @@ SQL >
       location,
       pathname,
       uniqState(session_id) as visits,
-      count() as hits
+      countState() as hits
     from
       analytics_hits
     group by


### PR DESCRIPTION
# Description

Fix bug detected in `analytics_pages` query, replacing `count()` with `countState()`:
https://tinybird-community.slack.com/archives/C02LELAGDFW/p1667669528003199

Until now, this bug was not affecting any workspace since Tinybird backend added the `_State` suffix to the query projection; however, it's necessary to explicitly add it to the pipe query to avoid any eventual issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in "personal site analytics" workspace
![image](https://user-images.githubusercontent.com/3041948/200155528-06d79b2e-a91d-4f86-839e-7635d6ab9a20.png)
![image](https://user-images.githubusercontent.com/3041948/200155541-4a16749e-255c-4165-85e3-5e6857ed2a6f.png)
![image](https://user-images.githubusercontent.com/3041948/200155549-8b950634-53cb-4003-8c4e-7f4901ea90dc.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have update the [CHANGELOG](https://github.com/tinybirdco/web-analytics-starter-kit/blob/main/CHANGELOG.md)
- [ ] New and existing unit tests pass locally with my changes
