### PR TITLE
Add Deploy to Vercel section with one click button

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ You will need to set up:
 
 If you want to customize & host your own dashboard, you can easily deploy the project to Vercel using the button below:
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Ftinybirdco%2Fweb-analytics-starter-kit&project-name=tinybird-web-analytics-starter-kit&repository-name=tinybird-web-analytics-starter-kit&root-directory=dashboard)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Ftinybirdco%2Fweb-analytics-starter-kit&project-name=tinybird-web-analytics-starter-kit&repository-name=tinybird-web-analytics-starter-kit&demo-title=Tinybird%20Web%20Analytics&demo-description=A%20privacy-first%20Web%20Analytics%20project%20built%20with%20Tinybird&demo-url=https%3A%2F%2Fanalytics.tinybird.co%2F&demo-image=https%3A%2F%2Fanalytics.tinybird.co%2Fbanner.png&root-directory=dashboard)
 
 
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ You will need to set up:
 - **The big picture:** [How an eCommerce giant replaced Google Analytics for privacy and scale](https://www.tinybird.co/blog-posts/ecommerce-google-analytics-alternative)
 </details>
 
+## Deploying the dashboard to Vercel
+
+If you want to customize & host your own dashboard, you can easily deploy the project to Vercel using the button below:
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Ftinybirdco%2Fweb-analytics-starter-kit&project-name=tinybird-web-analytics-starter-kit&repository-name=tinybird-web-analytics-starter-kit&root-directory=dashboard)
+
+
 
 ##  Authors
 


### PR DESCRIPTION
Adds a section to the README that describes deploying the dashboard to Vercel with a one-click button