### PR TITLE
Adding the possibility to set the domain for the cookie

### DIFF
--- a/middleware/src/index.js
+++ b/middleware/src/index.js
@@ -4,11 +4,12 @@
     let DATASOURCE = 'analytics_events';
     let globalAttributes = {};
 
-    let proxy, token, host;
+    let proxy, token, host, domain;
     if (document.currentScript) {
         host = document.currentScript.getAttribute('data-host');
         proxy = document.currentScript.getAttribute('data-proxy');
         token = document.currentScript.getAttribute('data-token');
+        domain = document.currentScript.getAttribute('data-domain')
         DATASOURCE = document.currentScript.getAttribute('data-datasource') || DATASOURCE;
        
         for (const attr of  document.currentScript.attributes) {
@@ -47,7 +48,13 @@
          *   - The next request will keep the same session id and extend the TTL for 30 more minutes
          */
         const sessionId = _getSessionId() || _uuidv4();
-        document.cookie = `${COOKIE_NAME}=${sessionId}; Max-Age=1800; path=/; secure`;
+        let cookieValue = `${COOKIE_NAME}=${sessionId}; Max-Age=1800; path=/; secure`
+
+        if (domain) {
+            cookieValue += `; domain=${domain}`
+        }
+
+        document.cookie = cookieValue;
     }
 
     /**

--- a/middleware/src/index.js
+++ b/middleware/src/index.js
@@ -9,7 +9,7 @@
         host = document.currentScript.getAttribute('data-host');
         proxy = document.currentScript.getAttribute('data-proxy');
         token = document.currentScript.getAttribute('data-token');
-        domain = document.currentScript.getAttribute('data-domain')
+        domain = document.currentScript.getAttribute('data-domain');
         DATASOURCE = document.currentScript.getAttribute('data-datasource') || DATASOURCE;
        
         for (const attr of  document.currentScript.attributes) {


### PR DESCRIPTION
# Description

Allow setting the domain for the cookie using `data-domain` in the script. The main use case is allowing to share the cookie in different subdomains.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
