### PR TITLE
Corrected country widget label

### DIFF
--- a/dashboard/components/TopLocationsWidget/TopLocationsWidget.tsx
+++ b/dashboard/components/TopLocationsWidget/TopLocationsWidget.tsx
@@ -1,10 +1,10 @@
-import Widget from '../Widget'
-import useTopLocations from '../../lib/hooks/use-top-locations'
 import { BarList } from '@tremor/react'
+import { TopLocationsSorting } from '../../lib/types/top-locations'
+import Widget from '../Widget'
+import { cx } from '../../lib/utils'
 import { useMemo } from 'react'
 import useParams from '../../lib/hooks/use-params'
-import { TopLocationsSorting } from '../../lib/types/top-locations'
-import { cx } from '../../lib/utils'
+import useTopLocations from '../../lib/hooks/use-top-locations'
 
 export default function TopLocationsWidget() {
   const { data, status, warning } = useTopLocations()
@@ -23,7 +23,7 @@ export default function TopLocationsWidget() {
 
   return (
     <Widget>
-      <Widget.Title>Top Pages</Widget.Title>
+      <Widget.Title>Top Countries</Widget.Title>
       <Widget.Content
         status={status}
         noData={!data?.data?.length}


### PR DESCRIPTION
# Description

There was a issue with country widget label. Instead of "Top Countries" it is "Top Pages" fixed that.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
