### PR TITLE
Fix data source partition key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,28 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.5.0] - 2023-04-12
+
+### Fixed
+
+- [Data project] Fix partition key
 
 ## [1.4.0] - 2023-04-12
+
 ### Added
+
 - [Script] Add support to set the domain for the cookie
 
 ## [1.3.0] - 2023-03-15
+
 ### Added
+
 - [Script] Add support to send attributes set in the script tag
 
 ## [1.2.3] - 2022-11-06
+
 ### Fixed
+
 - [Dashboard] Fix total KPIs for arbitrary date ranges (#37)
 - [Dashboard] Fix tooltip for the last data point in the chart
-- [Data project]  Fix `analytics_pages` query
+- [Data project] Fix `analytics_pages` query
 
 ## [1.2.2] - 2022-09-28
+
 ### Fixed
+
 - [Dashboard] Stop using Google's favicon service (#30)
 - [Script] Fix `Content-Type` (#33)
 
 ## [1.2.1] - 2022-09-27
+
 ### Fixed
+
 - [Script] Remove source maps (#24)
 - [Dashboard] Fix UTC date detection (#25)
 - [Dashboard] Improve domain guessing
@@ -36,22 +52,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Dashboard] Fix scroll behaviour (#17)
 
 ## [1.2.0] - 2022-09-06
+
 ### Changed
+
 - [Dashboard] Optmize bundle size and Core Web Vitals
 - [Script] Use `XMLHttpRequest` instead of `sendBeacon`
 
 ## [1.1.0] - 2022-09-05
+
 ### Changed
+
 - [Script] Improve script listeners, now can be imported as `defer`
 
 ### Added
+
 - [Dashboard] Add tracking script to dashboard
 
 ### Fixed
+
 - [Dashboard] Use Tailwind theme colors
 
 ## [1.0.0] - 2022-09-02
+
 ### Added
+
 - [Data project] Create data project template
 - [Middleware] Add Vercel middleware
 - [Script] Add tracking script
@@ -61,6 +85,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.2.3]: https://github.com/tinybirdco/web-analytics-starter-kit/compare/1.2.2...1.2.3
 [1.2.2]: https://github.com/tinybirdco/web-analytics-starter-kit/compare/1.2.1...1.2.2
 [1.2.1]: https://github.com/tinybirdco/web-analytics-starter-kit/compare/1.2.0...1.2.1
-[1.2.0]: https://github.com/tinybirdco/web-analytics-starter-kit/compare/1.1.0...1.2.0
+[1.2.0]: https://github.com/tinybirdco//compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/tinybirdco/web-analytics-starter-kit/compare/1.1.0...1.0.0
 [1.0.0]: https://github.com/tinybirdco/web-analytics-starter-kit/tree/1.0.0

--- a/tinybird/datasources/analytics_events.datasource
+++ b/tinybird/datasources/analytics_events.datasource
@@ -11,6 +11,6 @@ SCHEMA >
     `payload` String `json:$.payload`
 
 ENGINE MergeTree
-ENGINE_PARTITION_KEY toYYYYMM(timestamp)
+ENGINE_PARTITION_KEY toYear(timestamp)
 ENGINE_SORTING_KEY timestamp
 ENGINE_TTL timestamp + toIntervalDay(60)

--- a/tinybird/datasources/analytics_pages_mv.datasource
+++ b/tinybird/datasources/analytics_pages_mv.datasource
@@ -8,5 +8,5 @@ SCHEMA >
     `hits` AggregateFunction(count)
 
 ENGINE AggregatingMergeTree
-ENGINE_PARTITION_KEY toYYYYMM(date)
+ENGINE_PARTITION_KEY toYear(date)
 ENGINE_SORTING_KEY date, device, browser, location, pathname

--- a/tinybird/datasources/analytics_sessions_mv.datasource
+++ b/tinybird/datasources/analytics_sessions_mv.datasource
@@ -9,5 +9,5 @@ SCHEMA >
     `hits` AggregateFunction(count)
 
 ENGINE AggregatingMergeTree
-ENGINE_PARTITION_KEY toYYYYMM(date)
+ENGINE_PARTITION_KEY toYear(date)
 ENGINE_SORTING_KEY date, session_id

--- a/tinybird/datasources/analytics_sources_mv.datasource
+++ b/tinybird/datasources/analytics_sources_mv.datasource
@@ -8,5 +8,5 @@ SCHEMA >
     `hits` AggregateFunction(count)
 
 ENGINE AggregatingMergeTree
-ENGINE_PARTITION_KEY toYYYYMM(date)
+ENGINE_PARTITION_KEY toYear(date)
 ENGINE_SORTING_KEY date, device, browser, location, referrer


### PR DESCRIPTION
# Description
We need to replace the partition key with `toYear(timestamp)` to avoid this error:
```ClickHouse error, Code: 252. DB::Exception: Too many partitions for single INSERT block (more than 12). The limit is controlled by 'max_partitions_per_insert_block' setting. Large number of partitions is a common misconception. It will lead to severe negative performance impact, including slow server startup, slow INSERT queries and slow SELECT queries. Recommended total number of partitions for a table is under 1000..10000. Please note, that partitioning is not intended to speed up SELECT queries (ORDER BY key is sufficient to make range queries fast). Partitions are intended for data manipulation (DROP PARTITION, etc). (TOO_MANY_PARTS) (version 23.8.2.7 (official build))\n```
