### PR TITLE
[#90] Fix the session count in top_devices and top_browsers, using an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+- [Data project]  Fix `top_devices` and `top_browsers` session count (#90)
 
 ## [1.4.0] - 2023-04-12
 ### Added

--- a/tinybird/pipes/top_browsers.pipe
+++ b/tinybird/pipes/top_browsers.pipe
@@ -11,8 +11,8 @@ DESCRIPTION >
 
 SQL >
     %
-    select browser, uniqMerge(visits) as visits, countMerge(hits) as hits
-    from analytics_sources_mv
+    select browser, uniq(session_id) as visits, countMerge(hits) as hits
+    from analytics_sessions_mv
     where
         {% if defined(date_from) %}
             date

--- a/tinybird/pipes/top_devices.pipe
+++ b/tinybird/pipes/top_devices.pipe
@@ -11,8 +11,8 @@ DESCRIPTION >
 
 SQL >
     %
-    select device, uniqMerge(visits) as visits, countMerge(hits) as hits
-    from analytics_sources_mv
+    select device, uniq(session_id) as visits, countMerge(hits) as hits
+    from analytics_sessions_mv
     where
         {% if defined(date_from) %}
             date


### PR DESCRIPTION
# Description

Using `analytics_sessions_mv` instead of `analytics_sources_mv` in the `top_devices` and `top_browsers` endpoints.

Another positive side effect is that those endpoint will perform better at scale, given the cardinality of `analytics_sessions_mv` is lower.

Fixes #90

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# How Has This Been Tested?

I was able to reproduce this issue:

![image](https://github.com/user-attachments/assets/ff3b086f-93c5-40d8-82b5-e62c35cdcab4)

- [X] Test `top_devices` endpoint reports and accurate session count with the change
- [X] Same for `top_browsers`

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have update the [CHANGELOG](https://github.com/tinybirdco/web-analytics-starter-kit/blob/main/CHANGELOG.md)
- [X] New and existing unit tests pass locally with my changes
