### PR TITLE
Improve detection of sources

### DIFF
--- a/tinybird/pipes/analytics_hits.pipe
+++ b/tinybird/pipes/analytics_hits.pipe
@@ -18,6 +18,7 @@ SQL >
         JSONExtractString(payload, 'referrer') as referrer,
         JSONExtractString(payload, 'pathname') as pathname,
         JSONExtractString(payload, 'href') as href,
+        domainWithoutWWW(href) as current_domain,
         lower(JSONExtractString(payload, 'user-agent')) as user_agent
     FROM analytics_events
     where action = 'page_hit'
@@ -33,6 +34,7 @@ SQL >
         referrer,
         pathname,
         href,
+        current_domain,
         case
             when match(user_agent, 'wget|ahrefsbot|curl|urllib|bitdiscovery|\+https://|googlebot')
             then 'bot'

--- a/tinybird/pipes/analytics_sources.pipe
+++ b/tinybird/pipes/analytics_sources.pipe
@@ -3,7 +3,6 @@ DESCRIPTION >
     Aggregate by referral and calculate session and hits
 
 SQL >
-    WITH (SELECT domainWithoutWWW(href) FROM analytics_hits LIMIT 1) AS currenct_domain
     SELECT
         toDate(timestamp) AS date,
         device,
@@ -13,7 +12,7 @@ SQL >
         uniqState(session_id) AS visits,
         countState() AS hits
     FROM analytics_hits
-    WHERE domainWithoutWWW(referrer) != currenct_domain
+    WHERE domainWithoutWWW(referrer) != current_domain
     GROUP BY date, device, browser, location, referrer
 
 TYPE MATERIALIZED


### PR DESCRIPTION
# Description

Detection of sources in  `analytics_sources.pipe` is done using the current domain from the first line. This works fine on setups where there is only a single source, but when there are many it can lead to false positives: the current domain may change from line to line. We want to detect the current domain from each event.

Fixes #101 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested in a test project (server `gcp-wadus6`). Events are processed correctly.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have update the [CHANGELOG](https://github.com/tinybirdco/web-analytics-starter-kit/blob/main/CHANGELOG.md)
- [ ] New and existing unit tests pass locally with my changes
