### PR TITLE
fallback to new uuid if no cookie

### DIFF
--- a/middleware/src/index.js
+++ b/middleware/src/index.js
@@ -195,6 +195,8 @@
     payload = Object.assign({}, JSON.parse(payload), globalAttributes)
     payload = JSON.stringify(payload)
 
+    const session_id = _getSessionId() || _uuidv4()
+
     const request = new XMLHttpRequest()
     request.open('POST', url, true)
     request.setRequestHeader('Content-Type', 'application/json')
@@ -203,7 +205,7 @@
         timestamp: new Date().toISOString(),
         action: name,
         version: '1',
-        session_id: _getSessionId(),
+        session_id,
         payload,
       })
     )


### PR DESCRIPTION
sending an event first calls _setSessionId to set a session if one does not exist
then request.send calls _getSessionId and assumes it is set

however, if storage is blocked, the session id is never stored and _getSessionId returns undefined, so a session_id param is never sent in the payload. this causes tinybird to quarantine the row because it fails the schema validation.

this PR simply changes it to `_getSessionId() || _uuidv4()` so that a new uuidv4 is generated if we cannot get a sessionID from storage. this will have a negative consequence that we can end up with lots of unique sessionIDs, but it will present rows from being quarantined.