### PR TITLE
feat: add data-tb_* attribute support to global attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ These parameters can be used with the tracker snippet:
 
 ### Implementing custom attributes
 
- Attributes name must have **tb\_** prefix. Every attribute included with this requirement would be saved in the payload column of your `analytics_events` datasource and will be included in every event. 
+ Attributes name must have **data-tb\_** prefix. Every attribute included with this requirement would be saved in the payload column of your `analytics_events` datasource and will be included in every event. 
  
  For example:
 
@@ -68,7 +68,7 @@ These parameters can be used with the tracker snippet:
 <script
   src="https://unpkg.com/@tinybirdco/flock.js"
   data-token="TOKEN-ID"
-  tb_customer_id="CUSTOMER_ID"
+  data-tb_customer_id="CUSTOMER_ID"
 ></script>
 ```
 

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tinybirdco/flock.js",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tinybirdco/flock.js",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.6",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/flock.js",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "dist/index.js",
   "description": "Tinybird web analytics tracking script",
   "author": "Tinybird team",

--- a/middleware/src/index.js
+++ b/middleware/src/index.js
@@ -33,6 +33,9 @@
       if (attr.name.startsWith('tb_')) {
         globalAttributes[attr.name.slice(3)] = attr.value
       }
+      if (attr.name.startsWith('data-tb_')) {
+        globalAttributes[attr.name.slice(8)] = attr.value
+      }
     }
   }
 


### PR DESCRIPTION
Next.js <Script /> component only allows valid HTML attributes and data-* attributes to be passed as props.

Keeping all code for backwards compatibility.