### PR TITLE
Fix pnpm deploy command conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "pnpm --filter @tinybirdco/analytics-dashboard lint",
     "tinybird:dev": "pnpm --filter @tinybirdco/analytics-client dev",
     "tinybird:build": "pnpm --filter @tinybirdco/analytics-client build",
-    "tinybird:deploy": "pnpm --filter @tinybirdco/analytics-client deploy",
+    "tinybird:deploy": "pnpm --filter @tinybirdco/analytics-client run deploy",
     "tinybird:preview": "pnpm --filter @tinybirdco/analytics-client preview"
   },
   "engines": {


### PR DESCRIPTION
Adds 'run' directive to tinybird:deploy script to avoid conflict with pnpm's built-in deploy command.

The tinybird:deploy script was calling 'pnpm deploy' which pnpm interprets as its built-in deploy command rather than the npm script. This fix explicitly invokes the npm script by using 'pnpm run deploy'.

This resolves the error: `ERR_PNPM_INVALID_DEPLOY_TARGET This command requires one parameter`