### PR TITLE
Add root package.json to tinybird CD workflow triggers

### DIFF
--- a/.github/workflows/tinybird-cd.yml
+++ b/.github/workflows/tinybird-cd.yml
@@ -1,10 +1,12 @@
 name: Tinybird - CD Workflow
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
     paths:
+      - "package.json"
       - "tinybird/package.json"
       - "tinybird/tinybird.json"
       - "tinybird/**/*.ts"
@@ -14,7 +16,7 @@ env:
   TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
 
 jobs:
-  ci:
+  cd:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/tinybird-cd.yml
+++ b/.github/workflows/tinybird-cd.yml
@@ -5,11 +5,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "package.json"
-      - "tinybird/package.json"
-      - "tinybird/tinybird.json"
-      - "tinybird/**/*.ts"
 
 env:
   TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}


### PR DESCRIPTION
Triggers the tinybird CD workflow when the root package.json changes, since it contains the tinybird:deploy script that orchestrates the deployment.