### PR TITLE
chore: bump version to 1.7.1 in package.json for release

### DIFF
--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/flock.js",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "main": "dist/index.js",
   "description": "Tinybird web analytics tracking script",
   "author": "Tinybird team",


### PR DESCRIPTION
I only had to increase one version, the rest seems automated compared to the last release.